### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -13,7 +13,7 @@ GSMServer	KEYWORD1	GSMServerConstructor
 GSMModem	KEYWORD1	GSMModemConstructor
 GSMScanner	KEYWORD1	GSMScannerConstructor
 GSMPIN	KEYWORD1	GSMPINConstructor
-GSMBand KEYWORD1	GSMBandConstructor
+GSMBand	KEYWORD1	GSMBandConstructor
 
 #######################################
 # Methods and Functions 


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords