### PR TITLE
Replace boolean type with bool in examples

### DIFF
--- a/examples/GsmWebClient/GsmWebClient.ino
+++ b/examples/GsmWebClient/GsmWebClient.ino
@@ -46,7 +46,7 @@ void setup() {
 
   Serial.println("Starting Arduino web client.");
   // connection state
-  boolean notConnected = true;
+  bool notConnected = true;
 
   // After starting the modem with GSM.begin()
   // attach the shield to the GPRS network with the APN, login and password

--- a/examples/GsmWebServer/GsmWebServer.ino
+++ b/examples/GsmWebServer/GsmWebServer.ino
@@ -40,7 +40,7 @@ void setup() {
   }
 
   // connection state
-  boolean notConnected = true;
+  bool notConnected = true;
 
   // Start GSM shield
   // If your SIM has PIN, pass it as a parameter of begin() in quotes

--- a/examples/MakeVoiceCall/MakeVoiceCall.ino
+++ b/examples/MakeVoiceCall/MakeVoiceCall.ino
@@ -43,7 +43,7 @@ void setup() {
   Serial.println("Make Voice Call");
 
   // connection state
-  boolean notConnected = true;
+  bool notConnected = true;
 
   // Start GSM shield
   // If your SIM has PIN, pass it as a parameter of begin() in quotes

--- a/examples/ReceiveSMS/ReceiveSMS.ino
+++ b/examples/ReceiveSMS/ReceiveSMS.ino
@@ -40,7 +40,7 @@ void setup() {
   Serial.println("SMS Messages Receiver");
 
   // connection state
-  boolean notConnected = true;
+  bool notConnected = true;
 
   // Start GSM connection
   while (notConnected) {

--- a/examples/ReceiveVoiceCall/ReceiveVoiceCall.ino
+++ b/examples/ReceiveVoiceCall/ReceiveVoiceCall.ino
@@ -44,7 +44,7 @@ void setup() {
   Serial.println("Receive Voice Call");
 
   // connection state
-  boolean notConnected = true;
+  bool notConnected = true;
 
   // Start GSM shield
   // If your SIM has PIN, pass it as a parameter of begin() in quotes

--- a/examples/SendSMS/SendSMS.ino
+++ b/examples/SendSMS/SendSMS.ino
@@ -40,7 +40,7 @@ void setup() {
   Serial.println("SMS Messages Sender");
 
   // connection state
-  boolean notConnected = true;
+  bool notConnected = true;
 
   // Start GSM shield
   // If your SIM has PIN, pass it as a parameter of begin() in quotes

--- a/examples/Tools/BandManagement/BandManagement.ino
+++ b/examples/Tools/BandManagement/BandManagement.ino
@@ -55,7 +55,7 @@ void loop() {
   Serial.print("\nConfiguring band ");
   Serial.println(newBandName);
   // Change the band
-  boolean operationSuccess;
+  bool operationSuccess;
   operationSuccess = band.setBand(newBandName);
   // Tell the user if the operation was OK
   if (operationSuccess) {

--- a/examples/Tools/GsmScanNetworks/GsmScanNetworks.ino
+++ b/examples/Tools/GsmScanNetworks/GsmScanNetworks.ino
@@ -49,7 +49,7 @@ void setup() {
   scannerNetworks.begin();
 
   // connection state
-  boolean notConnected = true;
+  bool notConnected = true;
 
   // Start GSM shield
   // If your SIM has PIN, pass it as a parameter of begin() in quotes

--- a/examples/Tools/PinManagement/PinManagement.ino
+++ b/examples/Tools/PinManagement/PinManagement.ino
@@ -26,7 +26,7 @@ GSMPIN PINManager;
 String user_input = "";
 
 // authenticated with PIN code
-boolean auth = false;
+bool auth = false;
 
 // serial monitor result messages
 String oktext = "OK";

--- a/examples/Tools/TestGPRS/TestGPRS.ino
+++ b/examples/Tools/TestGPRS/TestGPRS.ino
@@ -41,7 +41,7 @@ char path[] = "/";
 String response = "";
 
 // use a proxy
-boolean use_proxy = false;
+bool use_proxy = false;
 
 void setup() {
   // initialize serial communications and wait for port to open:
@@ -138,7 +138,7 @@ void loop() {
     }
     Serial.print("Receiving response...");
 
-    boolean test = true;
+    bool test = true;
     while (test) {
       // if there are incoming bytes available
       // from the server, read and check them

--- a/examples/Tools/TestWebServer/TestWebServer.ino
+++ b/examples/Tools/TestWebServer/TestWebServer.ino
@@ -44,7 +44,7 @@ void setup() {
 
   Serial.println("starting,..");
   // connection state
-  boolean connected = true;
+  bool connected = true;
 
   // Start GSM shield
   // If your SIM has PIN, pass it as a parameter of begin() in quotes


### PR DESCRIPTION
Replace boolean type with bool in examples

This is part of a move to encourage use of the standard bool type over Arduino's non-standard boolean type alias.

As approved by cmaglie: https://github.com/arduino/Arduino/issues/6657#issuecomment-355597633